### PR TITLE
Webapp 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^5.0.3",
     "react-router-dom": "^4.1.1",
     "react-search-input": "^0.11.2",
+    "react-onclickoutside": "^6.1.1",
     "react-spinkit": "^3.0.0",
     "reduce-reducers": "^0.1.2",
     "redux": "^3.6.0",

--- a/src/components/LanguageFlyout/index.js
+++ b/src/components/LanguageFlyout/index.js
@@ -25,7 +25,6 @@ let LanguageElement = connect()(class extends React.Component {
     let languageCode = this.props.language.code
     this.props.dispatch(setLanguage(languageCode))
     this.props.languageCallback(languageCode)
-    this.props.flyout.toggle()
   }
 
   render () {
@@ -42,29 +41,19 @@ let LanguageElement = connect()(class extends React.Component {
 export default class LanguageFlyout extends React.Component {
   static propTypes = {
     languages: PropTypes.arrayOf(PropTypes.instanceOf(LanguageModel)).isRequired,
-    languageCallback: PropTypes.func,
+    languageCallback: PropTypes.func.isRequired,
     currentLanguage: PropTypes.string.isRequired
-  }
-
-  constructor (props) {
-    super(props)
-    this.state = {open: false}
-  }
-
-  toggle () {
-    this.setState({open: !this.state.open})
-    return this.state.open
   }
 
   render () {
     return (
-      <div className={cx(style.languageFlyout, this.state.open ? style.languageFlyoutShow : '')}>
+      <div className={style.languageFlyout}>
         {
           this.props.languages.map(language => (
               <LanguageElement
                 key={language.code}
                 flyout={this}
-                languageCallback={this.props.languageCallback || (() => {})}
+                languageCallback={this.props.languageCallback}
                 active={this.props.currentLanguage === language.code}
                 language={language}
               />

--- a/src/components/LanguageFlyout/index.js
+++ b/src/components/LanguageFlyout/index.js
@@ -11,7 +11,7 @@ let LanguageElement = connect()(class extends React.Component {
   static propTypes = {
     flyout: PropTypes.any.isRequired,
     language: PropTypes.instanceOf(LanguageModel).isRequired,
-    languageCallback: PropTypes.func.isRequired,
+    languageCallback: PropTypes.func,
     active: PropTypes.bool.isRequired
   }
 

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -1,24 +1,18 @@
 .language-flyout {
   position: fixed;
   z-index: 1000;
-
   display: flex;
   width: 100%;
   height: 100px;
-
   transform: scale(0.9);
   transform-origin: center top;
-
   justify-content: center;
   box-shadow: 0 2px 5px -2px rgba(0, 0, 0, 0.2);
   opacity: 0;
-
   font-family: 'Raleway', 'El Messiri', sans-serif;
   text-align: center;
-
   transition: transform 0.2s, opacity 0.2s;
   background-color: white;
-
   pointer-events: none;
 }
 
@@ -34,13 +28,17 @@
   font-size: 20px;
   line-height: 100px;
   text-align: center;
+  transition: background-color 0.2s, border-radius 0.2s;
+  border-radius: 30px;
   user-select: none;
 }
 
-.elementActive {
+.element-active {
   font-weight: 900;
 }
 
 .element:hover {
-  background-color: #FBDA16;
+  background-color: rgba(251, 218, 24, 0.5);
+  border-radius: 0;
+  cursor: pointer;
 }

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -1,16 +1,16 @@
 .language-flyout {
   display: flex;
-  flex-flow: row wrap;
   width: 100%;
+  flex-flow: row wrap;
   justify-content: center;
   font-family: 'Raleway', 'El Messiri', sans-serif;
   text-align: center;
 }
 
 .element {
+  height: 100px;
   min-width: 90px;
   max-width: 120px;
-  height: 100%;
   flex: 1 1 80px;
   font-size: 20px;
   line-height: 100px;

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -1,15 +1,13 @@
 .language-flyout {
-  display: flex;
   width: 100%;
-  height: 100px;
-  justify-content: center;
   font-family: 'Raleway', 'El Messiri', sans-serif;
   text-align: center;
 }
 
 .element {
+  display: inline-block;
   width: 100px;
-  height: 100%;
+  height: 100px;
   font-size: 20px;
   line-height: 100px;
   text-align: center;

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -1,13 +1,17 @@
 .language-flyout {
+  display: flex;
+  flex-flow: row wrap;
   width: 100%;
+  justify-content: center;
   font-family: 'Raleway', 'El Messiri', sans-serif;
   text-align: center;
 }
 
 .element {
-  display: inline-block;
-  width: 100px;
-  height: 100px;
+  min-width: 90px;
+  max-width: 120px;
+  height: 100%;
+  flex: 1 1 80px;
   font-size: 20px;
   line-height: 100px;
   text-align: center;

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -11,7 +11,7 @@
   height: 100px;
   min-width: 90px;
   max-width: 120px;
-  flex: 1 1 80px;
+  flex: 1 1 90px;
   font-size: 20px;
   line-height: 100px;
   text-align: center;

--- a/src/components/LanguageFlyout/style.css
+++ b/src/components/LanguageFlyout/style.css
@@ -1,25 +1,10 @@
 .language-flyout {
-  position: fixed;
-  z-index: 1000;
   display: flex;
   width: 100%;
   height: 100px;
-  transform: scale(0.9);
-  transform-origin: center top;
   justify-content: center;
-  box-shadow: 0 2px 5px -2px rgba(0, 0, 0, 0.2);
-  opacity: 0;
   font-family: 'Raleway', 'El Messiri', sans-serif;
   text-align: center;
-  transition: transform 0.2s, opacity 0.2s;
-  background-color: white;
-  pointer-events: none;
-}
-
-.language-flyout-show {
-  transform: scale(1);
-  opacity: 1;
-  pointer-events: auto;
 }
 
 .element {

--- a/src/components/Layout/Header.css
+++ b/src/components/Layout/Header.css
@@ -38,10 +38,6 @@
   padding: var(--logo-padding);
 }
 
-.item-active {
-  background-color: #FBDA16;
-}
-
 .item {
   display: flex;
   height: 100%;
@@ -52,7 +48,60 @@
   margin: 0 10px;
   font-size: 3rem;
   text-align: center;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, border-radius 0.2s;
+  border-radius: 40px;
+}
+
+.drop-down-item > .item {
+  width: 100%;
+  margin: 0;
+}
+
+.item:hover {
+  background-color: rgba(251, 218, 24, 0.5);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.item-active,
+.item-active:hover {
+  background-color: #FBDA16;
+  border-radius: 0;
+}
+
+.drop-down-item {
+  display: flex;
+  height: 100%;
+  max-width: 100px;
+  flex-direction: column;
+  align-content: center;
+  justify-content: center;
+  margin: 0 10px;
+  font-size: 3rem;
+  text-align: center;
+}
+
+.drop-down {
+  position: absolute;
+  top: 100px;
+  right: 0;
+  width: 100%;
+  transform: scale(0.9);
+  transform-origin: center top;
+  justify-content: center;
+  box-shadow: 0 2px 5px -2px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  font-family: 'Raleway', 'El Messiri', sans-serif;
+  text-align: center;
+  transition: transform 0.2s, opacity 0.2s;
+  background-color: white;
+  pointer-events: none;
+}
+
+.drop-down-active {
+  transform: scale(1);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .item-language {

--- a/src/components/Layout/Header.css
+++ b/src/components/Layout/Header.css
@@ -12,10 +12,9 @@
   right: 0;
   left: 0;
   z-index: 1000;
-
   display: flex;
+  width: 100%;
   height: 100px;
-  align-items: center;
   background-color: #FAFAFA;
 }
 
@@ -27,10 +26,8 @@
 
 .logo {
   height: 100%;
-  flex-grow: 1;
   order: 0;
-
-  padding: 20px;
+  padding: 0 20px;
 }
 
 .logo > img {
@@ -38,22 +35,20 @@
   padding: var(--logo-padding);
 }
 
-.item {
+.item,
+.drop-down-item {
   display: flex;
+  width: 100px;
   height: 100%;
-  max-width: 100px;
-  flex-direction: column;
-  align-content: center;
+  align-items: center;
   justify-content: center;
   margin: 0 10px;
   font-size: 3rem;
-  text-align: center;
   transition: background-color 0.2s, border-radius 0.2s;
   border-radius: 40px;
 }
 
 .drop-down-item > .item {
-  width: 100%;
   margin: 0;
 }
 
@@ -69,18 +64,6 @@
   border-radius: 0;
 }
 
-.drop-down-item {
-  display: flex;
-  height: 100%;
-  max-width: 100px;
-  flex-direction: column;
-  align-content: center;
-  justify-content: center;
-  margin: 0 10px;
-  font-size: 3rem;
-  text-align: center;
-}
-
 .drop-down {
   position: absolute;
   top: 100px;
@@ -91,8 +74,6 @@
   justify-content: center;
   box-shadow: 0 2px 5px -2px rgba(0, 0, 0, 0.2);
   opacity: 0;
-  font-family: 'Raleway', 'El Messiri', sans-serif;
-  text-align: center;
   transition: transform 0.2s, opacity 0.2s;
   background-color: white;
   pointer-events: none;
@@ -105,11 +86,9 @@
 }
 
 .item-language {
-  flex-grow: 1;
   order: 2;
 }
 
 .item-location {
-  flex-grow: 1;
   order: 1;
 }

--- a/src/components/Layout/Header.css
+++ b/src/components/Layout/Header.css
@@ -35,6 +35,12 @@
   padding: var(--logo-padding);
 }
 
+.items-container {
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+}
+
 .item,
 .drop-down-item {
   display: flex;

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -32,7 +32,7 @@ class NavElement extends React.Component {
 class Header extends React.Component {
   static propTypes = {
     languageCallback: PropTypes.func,
-    currentLanguage: PropTypes.string.isRequired
+    currentLanguage: PropTypes.string
   }
 
   render () {

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -37,14 +37,14 @@ class Header extends React.Component {
 
   render () {
     return (
-      <header >
-        <div className={style.spacer}>
-          <div className={style.header}>
-            { /* Logo */}
-            <NavElement to={DEFAULT_NAVIGATION.home} className={style.logo}>
-              <img src={logo}/>
-            </NavElement>
-            { /* Location */}
+      <header className={style.spacer}>
+        <div className={style.header}>
+          { /* Logo */}
+          <NavElement to={DEFAULT_NAVIGATION.home} className={style.logo}>
+            <img src={logo}/>
+          </NavElement>
+          <div className={style.itemsContainer}>
+          { /* Location */}
             <NavElement to={DEFAULT_NAVIGATION.location} className={cx(style.item, style.itemLocation)}>
               <FontAwesome name='map-marker'/>
             </NavElement>
@@ -68,10 +68,10 @@ class Header extends React.Component {
  * @param state The current app state
  * @returns {{languagePayload: Payload}} The endpoint values from the state mapped to props
  */
-function mapeStateToProps (state) {
+function mapStateToProps (state) {
   return ({
     languagePayload: state.languages
   })
 }
 
-export default connect(mapeStateToProps)(Header)
+export default connect(mapStateToProps)(Header)

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -50,7 +50,7 @@ class Header extends React.Component {
             </NavElement>
             { /* Language */}
             {!isEmpty(this.props.languagePayload.data) &&
-            <HeaderDropDown className={style.itemLanguage} name="globe">
+            <HeaderDropDown className={style.itemLanguage} fontAwesome="globe">
               <LanguageFlyout
                   languageCallback={this.props.languageCallback}
                   languages={this.props.languagePayload.data}

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import FontAwesome from 'react-fontawesome'
+import HeaderDropDown from './HeaderDropDown'
 import { isEmpty } from 'lodash/lang'
 
 import style from './Header.css'
@@ -34,25 +35,6 @@ class Header extends React.Component {
     currentLanguage: PropTypes.string.isRequired
   }
 
-  constructor (props) {
-    super(props)
-    this.onLanguageClick = this.onLanguageClick.bind(this)
-    this.onLanguageElementClick = this.onLanguageElementClick.bind(this)
-    this.state = {languageActive: false}
-  }
-
-  onLanguageClick (event) {
-    event.preventDefault()
-
-    let newState = this.languageFlyout.toggle()
-    this.setState({languageActive: !newState})
-  }
-
-  onLanguageElementClick (code) {
-    this.setState({languageActive: !this.state.languageActive})
-    this.props.languageCallback(code)
-  }
-
   render () {
     return (
       <header >
@@ -68,21 +50,15 @@ class Header extends React.Component {
             </NavElement>
             { /* Language */}
             {!isEmpty(this.props.languagePayload.data) &&
-            <FontAwesome name='globe'
-                         className={cx(style.item, style.itemLanguage, this.state.languageActive ? style.itemActive : '')}
-                         onClick={this.onLanguageClick}/>
-            }
+            <HeaderDropDown className={style.itemLanguage} name="globe">
+              <LanguageFlyout
+                  languageCallback={this.props.languageCallback}
+                  languages={this.props.languagePayload.data}
+                  currentLanguage={this.props.currentLanguage}
+              />
+            </HeaderDropDown>}
           </div>
         </div>
-
-        {!isEmpty(this.props.languagePayload.data) &&
-        <LanguageFlyout
-          ref={(languageFlyout) => { this.languageFlyout = languageFlyout }}
-          languageCallback={this.onLanguageElementClick}
-          languages={this.props.languagePayload.data}
-          currentLanguage={this.props.currentLanguage}
-        />
-        }
       </header>
     )
   }

--- a/src/components/Layout/HeaderDropDown.js
+++ b/src/components/Layout/HeaderDropDown.js
@@ -31,7 +31,9 @@ class HeaderDropDown extends React.Component {
   render () {
     return (
       <div className={cx(this.props.className, style.dropDownItem)}>
-        <FontAwesome name={this.props.fontAwesome} className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
+        <FontAwesome name={this.props.fontAwesome}
+                     className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)}
+                     onClick={this.toggleDropDown}/>
         <div className={cx(style.dropDown, this.state.dropDownActive ? style.dropDownActive : '')}>
           {this.props.children}
         </div>

--- a/src/components/Layout/HeaderDropDown.js
+++ b/src/components/Layout/HeaderDropDown.js
@@ -31,7 +31,7 @@ class HeaderDropDown extends React.Component {
   render () {
     return (
       <div className={cx(this.props.className, style.dropDownItem)}>
-        <FontAwesome name={this.props.fontAwesome } className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
+        <FontAwesome name={this.props.fontAwesome} className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
         <div className={cx(style.dropDown, this.state.dropDownActive ? style.dropDownActive : '')}>
           {this.props.children}
         </div>

--- a/src/components/Layout/HeaderDropDown.js
+++ b/src/components/Layout/HeaderDropDown.js
@@ -8,7 +8,7 @@ import onClickOutside from 'react-onclickoutside'
 class HeaderDropDown extends React.Component {
   static propTypes = {
     className: PropTypes.string,
-    name: PropTypes.string.isRequired
+    fontAwesome: PropTypes.string.isRequired
   }
 
   constructor (props) {
@@ -31,7 +31,7 @@ class HeaderDropDown extends React.Component {
   render () {
     return (
       <div className={cx(this.props.className, style.dropDownItem)}>
-        <FontAwesome name={this.props.name } className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
+        <FontAwesome name={this.props.fontAwesome } className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
         <div className={cx(style.dropDown, this.state.dropDownActive ? style.dropDownActive : '')}>
           {this.props.children}
         </div>

--- a/src/components/Layout/HeaderDropDown.js
+++ b/src/components/Layout/HeaderDropDown.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import FontAwesome from 'react-fontawesome'
+import style from './Header.css'
+import onClickOutside from 'react-onclickoutside'
+
+class HeaderDropDown extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    name: PropTypes.string.isRequired
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = { dropDownActive: false }
+    this.toggleDropDown = this.toggleDropDown.bind(this)
+    this.handleClickOutside = this.handleClickOutside.bind(this)
+  }
+
+  toggleDropDown () {
+    this.setState({dropDownActive: !this.state.dropDownActive})
+  }
+
+  handleClickOutside () {
+    if (this.state.dropDownActive) {
+      this.toggleDropDown()
+    }
+  }
+
+  render () {
+    return (
+      <div className={cx(this.props.className, style.dropDownItem)}>
+        <FontAwesome name={this.props.name } className={cx(this.state.dropDownActive ? style.itemActive : '', style.item)} onClick={this.toggleDropDown}/>
+        <div className={cx(style.dropDown, this.state.dropDownActive ? style.dropDownActive : '')}>
+          {this.props.children}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default onClickOutside(HeaderDropDown)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6658,6 +6658,10 @@ react-i18next@^4.1.2:
   dependencies:
     hoist-non-react-statics "1.2.0"
 
+react-onclickoutside@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.1.1.tgz#9e680cdebd6c21878204e8a9f19ff413f8078397"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"


### PR DESCRIPTION
Goals of this branch:
- Close the modal flyout when the user clicks on any other element on the page
This was implemented using the npm package "react-onclickoutside". This package allows for easy access to an event called "onclickoutside", but events cant be interrupted in react, so the package is not suitable for modal dialogs (because it doesn't create an overlay but listens on document lvl). Since 'language-flyout' is a small dialog, we may not want to use a modal-dialog here (which can be irritating for desktop users).
I introduced 'HeaderDropDown' for general dropdown menus on the header, which cares for its openSate itself. So in future we can easily embed other dropdowns as well.
I allowed the languages in languageFlyout to wrap to another row when there's insufficient space. Unfortunately, sometimes this makes some languages look a bit lonely down there.
- Improve cursor feedback. This means the cursor should be in the click-state when a langauge is hovered
Done. Also added some dope hover effects.

Also, the a-tag of the Integreat logo "flex-grew" along the whole header (on desktop), so I moved the menu items that would align to the right in a container-div in order to align the header properly.