### PR TITLE
Replace http with https in disclaimer endpoint

### DIFF
--- a/src/endpoints/disclaimer.js
+++ b/src/endpoints/disclaimer.js
@@ -4,7 +4,7 @@ import PageModel from './models/PageModel'
 
 export default new Endpoint(
   'disclaimer',
-  'http://cms.integreat-app.de/{location}/{language}/wp-json/extensions/v0/modified_content/disclaimer?since={since}',
+  'https://cms.integreat-app.de/{location}/{language}/wp-json/extensions/v0/modified_content/disclaimer?since={since}',
   (json) => {
     return reduce(json, (result, page) => {
       if (page.status !== 'publish') {


### PR DESCRIPTION
The disclaimer page is blocked (in any browser) because of "loading mixed active content".
This only affects the live preview.
Problem: endpoint disclaimer.js requests an http version of cms.
Fix: replace http with https