### PR TITLE
WEBAPP-89: Fetch events in german

### DIFF
--- a/src/modules/app/containers/__tests__/__snapshots__/App.spec.js.snap
+++ b/src/modules/app/containers/__tests__/__snapshots__/App.spec.js.snap
@@ -64,7 +64,7 @@ exports[`App should match snapshot 1`] = `
           "responseOverride": undefined,
           "shouldRefetch": [Function],
           "startFetchAction": [Function],
-          "url": "https://cms.integreat-app.de/{location}/{language}/wp-json/extensions/v0/modified_content/events?since=1970-01-01T00:00:00Z",
+          "url": "https://cms.integreat-app.de/{location}/de/wp-json/extensions/v0/modified_content/events?since=1970-01-01T00:00:00Z",
         },
       ]
     }

--- a/src/modules/endpoint/endpoints/__tests__/events.spec.js
+++ b/src/modules/endpoint/endpoints/__tests__/events.spec.js
@@ -48,8 +48,8 @@ describe('events', () => {
   }
 
   test('should map state to urls', () => {
-    expect(events.mapStateToUrlParams({router: {params: {location: 'augsburg', language: 'de'}}}))
-      .toEqual({location: 'augsburg', language: 'de'})
+    expect(events.mapStateToUrlParams({router: {params: {location: 'augsburg'}}}))
+      .toEqual({location: 'augsburg'})
   })
 
   const toEventModel = (json) => new EventModel({

--- a/src/modules/endpoint/endpoints/events.js
+++ b/src/modules/endpoint/endpoints/events.js
@@ -4,8 +4,9 @@ import EndpointBuilder from '../EndpointBuilder'
 import EventModel from '../models/EventModel'
 
 export default new EndpointBuilder('events')
-  .withUrl('https://cms.integreat-app.de/{location}/{language}/wp-json/extensions/v0/modified_content/events?since=1970-01-01T00:00:00Z')
-  .withStateMapper().fromArray(['location', 'language'], (state, paramName) => state.router.params[paramName])
+  // fetch events from 'de' because most events aren't available in other languages
+  .withUrl('https://cms.integreat-app.de/{location}/de/wp-json/extensions/v0/modified_content/events?since=1970-01-01T00:00:00Z')
+  .withStateMapper().fromArray(['location'], (state, paramName) => state.router.params[paramName])
   .withMapper((json) => json
     .filter(event => event.status === 'publish')
     .map(event => new EventModel({


### PR DESCRIPTION
until our cms automatically duplicates not translated events, we always load events in 'de', no matter what language the user has selected 
