### PR TITLE
WEBAPP-343: Add rel='norefferer' to external links

### DIFF
--- a/src/modules/common/components/Tile.js
+++ b/src/modules/common/components/Tile.js
@@ -86,7 +86,7 @@ class Tile extends React.Component<PropsType> {
     } else {
       const inputs = []
       tile.postData.forEach((value, key) => inputs.unshift(<input type='hidden' value={value} key={key} name={key} />))
-      return <form method='POST' action={tile.path} target='_blank' rel='noreferrer'>
+      return <form method='POST' action={tile.path} target='_blank'>
         {inputs}
         <button type='submit'>{this.getTileContent()}</button>
       </form>

--- a/src/modules/common/components/Tile.js
+++ b/src/modules/common/components/Tile.js
@@ -82,11 +82,11 @@ class Tile extends React.Component<PropsType> {
     if (!tile.isExternalUrl) {
       return <CleanLink to={tile.path}>{this.getTileContent()}</CleanLink>
     } else if (!tile.postData) {
-      return <CleanAnchor href={tile.path} target='_blank'>{this.getTileContent()}</CleanAnchor>
+      return <CleanAnchor href={tile.path} target='_blank' rel='noreferrer'>{this.getTileContent()}</CleanAnchor>
     } else {
       const inputs = []
       tile.postData.forEach((value, key) => inputs.unshift(<input type='hidden' value={value} key={key} name={key} />))
-      return <form method='POST' action={tile.path} target='_blank'>
+      return <form method='POST' action={tile.path} target='_blank' rel='noreferrer'>
         {inputs}
         <button type='submit'>{this.getTileContent()}</button>
       </form>

--- a/src/modules/common/components/__tests__/__snapshots__/Tile.spec.js.snap
+++ b/src/modules/common/components/__tests__/__snapshots__/Tile.spec.js.snap
@@ -31,6 +31,7 @@ exports[`Tile should render a a-Tag if path is not an external url 1`] = `
 >
   <CleanAnchor
     href="https://example.com"
+    rel="noreferrer"
     target="_blank"
   >
     <Tile__ThumbnailSizer>
@@ -56,6 +57,7 @@ exports[`Tile should render a form-Tag if path is not an external url and has po
   <form
     action="https://example.com"
     method="POST"
+    rel="noreferrer"
     target="_blank"
   >
     <input

--- a/src/modules/common/components/__tests__/__snapshots__/Tile.spec.js.snap
+++ b/src/modules/common/components/__tests__/__snapshots__/Tile.spec.js.snap
@@ -57,7 +57,6 @@ exports[`Tile should render a form-Tag if path is not an external url and has po
   <form
     action="https://example.com"
     method="POST"
-    rel="noreferrer"
     target="_blank"
   >
     <input

--- a/src/modules/layout/components/ToolbarItem.js
+++ b/src/modules/layout/components/ToolbarItem.js
@@ -29,7 +29,7 @@ class ToolbarItem extends React.PureComponent<PropsType> {
   render () {
     const {href, text, icon} = this.props
     return (
-      <StyledToolbarItem href={href} target='_blank' data-tip={text}>
+      <StyledToolbarItem href={href} target='_blank' rel='noopener' data-tip={text}>
         <FontAwesomeIcon icon={icon} />
       </StyledToolbarItem>
     )

--- a/src/modules/layout/components/__tests__/__snapshots__/ToolbarItem.spec.js.snap
+++ b/src/modules/layout/components/__tests__/__snapshots__/ToolbarItem.spec.js.snap
@@ -4,6 +4,7 @@ exports[`ToolbarItem should render 1`] = `
 <ToolbarItem__StyledToolbarItem
   data-tip="Click here!"
   href="http://example.com"
+  rel="noopener"
   target="_blank"
 >
   <FontAwesomeIcon

--- a/src/routes/sprungbrett/components/SprungbrettListItem.js
+++ b/src/routes/sprungbrett/components/SprungbrettListItem.js
@@ -26,7 +26,7 @@ class SprungbrettListItem extends React.Component<PropsType> {
     const job = this.props.job
 
     return <ListElement>
-        <CleanAnchor href={job.url} target='_blank'>
+        <CleanAnchor href={job.url} target='_blank' rel='noreferrer'>
           <Title>{job.title}</Title>
           <Description>{job.location}</Description>
         </CleanAnchor>

--- a/src/routes/sprungbrett/components/__tests__/__snapshots__/SprungbrettListItem.spec.js.snap
+++ b/src/routes/sprungbrett/components/__tests__/__snapshots__/SprungbrettListItem.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`SprungbrettListItem should match snapshot 1`] = `
 <ListElement>
   <CleanAnchor
+    rel="noreferrer"
     target="_blank"
   >
     <SprungbrettListItem__Title>


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://integreat.atlassian.net/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.

For forms rel='noreffer'/rel='noopener' is not available. Our extras using forms(only Lehrstellenradar) can not be opened in the background btw.