### PR TITLE
WEBAPP-387: Fix internal linking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,14 @@ pipeline {
     }
     stage('Build') {
       steps {
-        sh 'yarn run build:debug'
+        script {
+          if (env.BRANCH_NAME == 'master') {
+            sh 'yarn run build'
+
+          } else {
+            sh 'yarn run build:debug'
+          }
+        }
         sh 'yarn run check:built'
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreat-webapp",
-  "version": "2018.09.1",
+  "version": "2018.10.0",
   "private": true,
   "engines": {
     "node": ">=6.9",

--- a/src/modules/common/components/RemoteContent.js
+++ b/src/modules/common/components/RemoteContent.js
@@ -25,8 +25,14 @@ class RemoteContent extends React.Component<PropsType> {
 
   handleClick = (event: MouseEvent) => {
     // https://stackoverflow.com/a/1000606
-    event.preventDefault ? event.preventDefault() : ((event: any).returnValue = false)
-    this.props.onInternLinkClick(new URL((event.currentTarget: any).href).pathname)
+    // $FlowFixMe
+    event.preventDefault ? event.preventDefault() : (event.returnValue = false)
+    const target: EventTarget | null = event.currentTarget
+
+    if (target instanceof HTMLAnchorElement) {
+      const href = target.href
+      this.props.onInternLinkClick(decodeURIComponent(new URL(decodeURIComponent(href)).pathname))
+    }
   }
 
   constructor () {


### PR DESCRIPTION
This url part was encoded twice. To fix this we first decode it when getting it from the DOM. Secondly we decode after the parsing with URL because it encodes internally.