### PR TITLE
WEBAPP-566: Polyfills breaking WebApp on IE 11

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,5 @@
 // @flow
 
-import './polyfills'
-
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,7 +1,0 @@
-// @flow
-
-import '@babel/polyfill'
-
-import 'whatwg-fetch'
-
-import 'url-polyfill'

--- a/tools/webpack.config.babel.js
+++ b/tools/webpack.config.babel.js
@@ -22,6 +22,12 @@ const createConfig = (env = {}) => {
   console.log('isDebug: ', isDebug)
   console.log('config_name: ', appConfigName)
 
+  const polyfills = [
+    '@babel/polyfill',
+    'whatwg-fetch',
+    'url-polyfill'
+  ]
+
   const config = {
     mode: isDebug ? 'development' : 'production',
     resolve: {
@@ -34,6 +40,7 @@ const createConfig = (env = {}) => {
     // The entry point for the bundle
     entry: [
       '!!style-loader!css-loader!normalize.css/normalize.css',
+      ...polyfills,
       'react-hot-loader/patch',
       /* The main entry point of your JavaScript application */
       './main.js'

--- a/tools/webpack.config.babel.js
+++ b/tools/webpack.config.babel.js
@@ -22,6 +22,8 @@ const createConfig = (env = {}) => {
   console.log('isDebug: ', isDebug)
   console.log('config_name: ', appConfigName)
 
+  // Add new polyfills here instead of importing them in the JavaScript code.
+  // This way it is ensured that polyfills are loaded before any other code which might require them.
   const polyfills = [
     '@babel/polyfill',
     'whatwg-fetch',


### PR DESCRIPTION
The fix is described here: https://github.com/facebook/react/issues/8379#issuecomment-273489824
The main problem was that @babel/polyfill was loaded after 'react-hot-loader/patch'
By moving the polyfills to the webpack config we aim we mitigate this in the future better

This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
