### PR TITLE
WEBAPP-570: Webpack-dev-server is broken on IE11 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,5 @@
 // @flow
 
-import './polyfills'
-
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,7 +1,0 @@
-// @flow
-
-import '@babel/polyfill'
-
-import 'whatwg-fetch'
-
-import 'url-polyfill'

--- a/tools/webpack.config.babel.js
+++ b/tools/webpack.config.babel.js
@@ -106,7 +106,9 @@ const createConfig = (env = {}) => {
         {
           test: /\.jsx?$/,
           // https://github.com/webpack/webpack/issues/2031#issuecomment-219040479
-          exclude: /node_modules\/(?!(strict-uri-encode)\/).*/,
+          // Packages mentioned here probably use ES6 syntax which IE11 does not support. This is a problem because
+          // in development mode webpack bundles the mentioned packages
+          exclude: /node_modules\/(?!(strict-uri-encode|strip-ansi)\/).*/,
           loader: 'babel-loader',
           options: babelConfig
         },

--- a/tools/webpack.config.babel.js
+++ b/tools/webpack.config.babel.js
@@ -22,6 +22,12 @@ const createConfig = (env = {}) => {
   console.log('isDebug: ', isDebug)
   console.log('config_name: ', appConfigName)
 
+  const polyfills = [
+    '@babel/polyfill',
+    'whatwg-fetch',
+    'url-polyfill'
+  ]
+
   const config = {
     mode: isDebug ? 'development' : 'production',
     resolve: {
@@ -34,6 +40,7 @@ const createConfig = (env = {}) => {
     // The entry point for the bundle
     entry: [
       '!!style-loader!css-loader!normalize.css/normalize.css',
+      ...polyfills,
       'react-hot-loader/patch',
       /* The main entry point of your JavaScript application */
       './main.js'


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
