### PR TITLE
WEBAPP-584: Fix general disclaimer

### DIFF
--- a/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
+++ b/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
@@ -2,11 +2,14 @@
 
 import { RouteConfig } from './RouteConfig'
 
+// This type should be exact, but flow has a bug preventing this: https://github.com/facebook/flow/issues/2977
+type RequiredPayloadsType = {}
+
 export const MAIN_DISCLAIMER_ROUTE = 'MAIN_DISCLAIMER'
 
 const mainDisclaimerRoute = '/disclaimer'
 
-class MainDisclaimerRouteConfig implements RouteConfig<void, void> {
+class MainDisclaimerRouteConfig implements RouteConfig<void, RequiredPayloadsType> {
   name = MAIN_DISCLAIMER_ROUTE
   route = mainDisclaimerRoute
   isLocationLayoutRoute = false
@@ -15,7 +18,7 @@ class MainDisclaimerRouteConfig implements RouteConfig<void, void> {
 
   getRoutePath = (): string => mainDisclaimerRoute
 
-  getRequiredPayloads = () => ({})
+  getRequiredPayloads = (): RequiredPayloadsType => ({})
 
   getLanguageChangePath = () => null
 

--- a/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
+++ b/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
@@ -15,7 +15,7 @@ class MainDisclaimerRouteConfig implements RouteConfig<void, void> {
 
   getRoutePath = (): string => mainDisclaimerRoute
 
-  getRequiredPayloads = () => {}
+  getRequiredPayloads = () => ({})
 
   getLanguageChangePath = () => null
 

--- a/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
+++ b/src/modules/app/route-configs/MainDisclaimerRouteConfig.js
@@ -2,8 +2,7 @@
 
 import { RouteConfig } from './RouteConfig'
 
-// This type should be exact, but flow has a bug preventing this: https://github.com/facebook/flow/issues/2977
-type RequiredPayloadsType = {}
+type RequiredPayloadsType = {||}
 
 export const MAIN_DISCLAIMER_ROUTE = 'MAIN_DISCLAIMER'
 
@@ -18,6 +17,7 @@ class MainDisclaimerRouteConfig implements RouteConfig<void, RequiredPayloadsTyp
 
   getRoutePath = (): string => mainDisclaimerRoute
 
+  // $FlowFixMe Flow has a bug preventing exact return types: https://github.com/facebook/flow/issues/2977
   getRequiredPayloads = (): RequiredPayloadsType => ({})
 
   getLanguageChangePath = () => null

--- a/src/modules/app/route-configs/NotFoundRouteConfig.js
+++ b/src/modules/app/route-configs/NotFoundRouteConfig.js
@@ -3,7 +3,10 @@
 import { NOT_FOUND } from 'redux-first-router'
 import type { RouteConfig } from './RouteConfig'
 
-class NotFoundRouteConfig implements RouteConfig<void, void> {
+// This type should be exact, but flow has a bug preventing this: https://github.com/facebook/flow/issues/2977
+type RequiredPayloadsType = {}
+
+class NotFoundRouteConfig implements RouteConfig<void, RequiredPayloadsType> {
   name = NOT_FOUND
   route = NOT_FOUND
   isLocationLayoutRoute = false
@@ -12,7 +15,7 @@ class NotFoundRouteConfig implements RouteConfig<void, void> {
 
   getRoutePath = (): string => NOT_FOUND
 
-  getRequiredPayloads = () => ({})
+  getRequiredPayloads = (): RequiredPayloadsType => ({})
 
   getLanguageChangePath = () => null
 

--- a/src/modules/app/route-configs/NotFoundRouteConfig.js
+++ b/src/modules/app/route-configs/NotFoundRouteConfig.js
@@ -3,8 +3,7 @@
 import { NOT_FOUND } from 'redux-first-router'
 import type { RouteConfig } from './RouteConfig'
 
-// This type should be exact, but flow has a bug preventing this: https://github.com/facebook/flow/issues/2977
-type RequiredPayloadsType = {}
+type RequiredPayloadsType = {||}
 
 class NotFoundRouteConfig implements RouteConfig<void, RequiredPayloadsType> {
   name = NOT_FOUND
@@ -15,6 +14,7 @@ class NotFoundRouteConfig implements RouteConfig<void, RequiredPayloadsType> {
 
   getRoutePath = (): string => NOT_FOUND
 
+  // $FlowFixMe Flow has a bug preventing exact return types: https://github.com/facebook/flow/issues/2977
   getRequiredPayloads = (): RequiredPayloadsType => ({})
 
   getLanguageChangePath = () => null

--- a/src/modules/app/route-configs/NotFoundRouteConfig.js
+++ b/src/modules/app/route-configs/NotFoundRouteConfig.js
@@ -12,7 +12,7 @@ class NotFoundRouteConfig implements RouteConfig<void, void> {
 
   getRoutePath = (): string => NOT_FOUND
 
-  getRequiredPayloads = () => {}
+  getRequiredPayloads = () => ({})
 
   getLanguageChangePath = () => null
 

--- a/src/modules/app/route-configs/__tests__/MainDisclaimerRouteConfig.spec.js
+++ b/src/modules/app/route-configs/__tests__/MainDisclaimerRouteConfig.spec.js
@@ -29,7 +29,7 @@ describe('MainDisclaimerRouteConfig', () => {
       sprungbrettJobsPayload: new Payload(true)
     }
 
-    expect(mainDisclaimerRouteConfig.getRequiredPayloads(allPayloads)).toBeUndefined()
+    expect(mainDisclaimerRouteConfig.getRequiredPayloads(allPayloads)).toEqual({})
   })
 
   it('should return the right page title', () => {

--- a/src/modules/app/route-configs/__tests__/MainDisclaimerRouteConfig.spec.js
+++ b/src/modules/app/route-configs/__tests__/MainDisclaimerRouteConfig.spec.js
@@ -38,7 +38,7 @@ describe('MainDisclaimerRouteConfig', () => {
       pathname: '/disclaimer',
       type: mainDisclaimerRouteConfig.name
     })
-    expect(mainDisclaimerRouteConfig.getPageTitle({ t, payloads: undefined, location, cityName: null }))
+    expect(mainDisclaimerRouteConfig.getPageTitle({ t, payloads: {}, location, cityName: null }))
       .toBe('pageTitles.mainDisclaimer')
   })
 
@@ -53,7 +53,7 @@ describe('MainDisclaimerRouteConfig', () => {
       type: mainDisclaimerRouteConfig.name
     })
     expect(mainDisclaimerRouteConfig.getLanguageChangePath({
-      payloads: undefined,
+      payloads: {},
       location,
       language: 'de'
     })).toBeNull()
@@ -65,6 +65,6 @@ describe('MainDisclaimerRouteConfig', () => {
       pathname: '/disclaimer',
       type: mainDisclaimerRouteConfig.name
     })
-    expect(mainDisclaimerRouteConfig.getFeedbackTargetInformation({ payloads: undefined, location })).toBeNull()
+    expect(mainDisclaimerRouteConfig.getFeedbackTargetInformation({ payloads: {}, location })).toBeNull()
   })
 })

--- a/src/modules/app/route-configs/__tests__/NotFoundRouteConfig.spec.js
+++ b/src/modules/app/route-configs/__tests__/NotFoundRouteConfig.spec.js
@@ -30,7 +30,7 @@ describe('NotFoundRouteConfig', () => {
       sprungbrettJobsPayload: new Payload(true)
     }
 
-    expect(notFoundRouteConfig.getRequiredPayloads(allPayloads)).toBeUndefined()
+    expect(notFoundRouteConfig.getRequiredPayloads(allPayloads)).toEqual({})
   })
 
   it('should return the right page title', () => {

--- a/src/modules/app/route-configs/__tests__/NotFoundRouteConfig.spec.js
+++ b/src/modules/app/route-configs/__tests__/NotFoundRouteConfig.spec.js
@@ -39,7 +39,7 @@ describe('NotFoundRouteConfig', () => {
       pathname: NOT_FOUND,
       type: notFoundRouteConfig.name
     })
-    expect(notFoundRouteConfig.getPageTitle({ t, payloads: undefined, location, cityName: null }))
+    expect(notFoundRouteConfig.getPageTitle({ t, payloads: {}, location, cityName: null }))
       .toBe('pageTitles.notFound')
   })
 
@@ -53,7 +53,7 @@ describe('NotFoundRouteConfig', () => {
       pathname: NOT_FOUND,
       type: notFoundRouteConfig.name
     })
-    expect(notFoundRouteConfig.getLanguageChangePath({ payloads: undefined, location, language: 'de' })).toBeNull()
+    expect(notFoundRouteConfig.getLanguageChangePath({ payloads: {}, location, language: 'de' })).toBeNull()
   })
 
   it('all functions should return the right feedback target information', () => {
@@ -62,6 +62,6 @@ describe('NotFoundRouteConfig', () => {
       pathname: NOT_FOUND,
       type: notFoundRouteConfig.name
     })
-    expect(notFoundRouteConfig.getFeedbackTargetInformation({ payloads: undefined, location })).toBeNull()
+    expect(notFoundRouteConfig.getFeedbackTargetInformation({ payloads: {}, location })).toBeNull()
   })
 })


### PR DESCRIPTION
Only thing missing was a pair of parantheses.
The same issue occurred for the NOT_FOUND route, so I also fixed it there.


This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
