### PR TITLE
WEBAPP-572: Bugfix calling console.error throws error in tests

### DIFF
--- a/src/modules/app/__tests__/fetchData.spec.js
+++ b/src/modules/app/__tests__/fetchData.spec.js
@@ -18,21 +18,15 @@ describe('fetchData', () => {
 
   let clock
   const mockedTime = 0
-  let prevError
 
   beforeEach(() => {
     clock = lolex.install({ now: mockedTime, toFake: [] })
-    prevError = console.error // todo: Find better way of allowing console.error
-    // $FlowFixMe
-    console.error = error => console.log(`Some expected error was thrown: ${error}`)
   })
 
   afterEach(() => {
     // $FlowFixMe
     fetch.resetMocks()
     clock.uninstall()
-    // $FlowFixMe
-    console.error = prevError
   })
 
   it('should fetch correctly if the data has not been fetched yet', async () => {

--- a/src/modules/feedback/components/__tests__/FeedbackBoxContainer.spec.js
+++ b/src/modules/feedback/components/__tests__/FeedbackBoxContainer.spec.js
@@ -393,18 +393,12 @@ describe('FeedbackBoxContainer', () => {
         sendingStatus='ERROR'
         t={t} />
     )
-    // set as workaround to override: console error to log
-    const prevError = console.error
-    // $FlowFixMe
-    console.error = error => console.log(`Some expected error was thrown: ${error}`)
 
     const instance = component.instance()
     instance.postFeedbackData = jest.fn().mockRejectedValue(new Error('Endpoint request failed'))
 
     await instance.handleSubmit()
     expect(mockOnSubmit).toHaveBeenCalledWith('ERROR')
-    // $FlowFixMe
-    console.error = prevError
   })
 
   it('should update state onCommentChanged', () => {

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -15,10 +15,5 @@ global.__CONFIG__ = integreatTestCmsBuildConfig
 
 // $FlowFixMe
 console.error = error => {
-  throw Error(error)
-}
-
-// $FlowFixMe
-console.warn = warn => {
-  throw Error(warn)
+  console.log(error)
 }

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -12,8 +12,3 @@ global.fetch = require('jest-fetch-mock')
 
 // Setup config mock
 global.__CONFIG__ = integreatTestCmsBuildConfig
-
-// $FlowFixMe
-console.error = error => {
-  console.log(error)
-}


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
