### PR TITLE
WEBAPP-616: Prevent failing if no release notes

### DIFF
--- a/tools/move-release-notes
+++ b/tools/move-release-notes
@@ -43,6 +43,11 @@ const moveReleaseNotes = async ({ newVersionName, deliverinoPrivateKey, owner, r
   const unreleasedReleaseNotes = unreleasedTree.data.tree.filter(it => it.path !== GITKEEP_FILE)
   const keepFile = unreleasedTree.data.tree.find(it => it.path === GITKEEP_FILE)
 
+  // Creating an empty tree is not possible
+  if (unreleasedReleaseNotes.length === 0) {
+    return
+  }
+
   const newVersionTree = await appOctokit.git.createTree({ owner, repo, tree: unreleasedReleaseNotes })
   const newUnreleasedTree = await appOctokit.git.createTree({ owner, repo, tree: [keepFile] })
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
