### PR TITLE
WEBAPP-646: Remove unused hijackRegExp property

### DIFF
--- a/src/modules/common/components/Page.js
+++ b/src/modules/common/components/Page.js
@@ -26,7 +26,6 @@ type PropsType = {|
   lastUpdate?: Moment,
   language: string,
   onInternalLinkClick: string => void,
-  hijackRegExp?: RegExp,
   children?: React.Node
 |}
 
@@ -36,7 +35,7 @@ type PropsType = {|
 class Page extends React.PureComponent<PropsType> {
   render () {
     const {
-      title, defaultThumbnailSrc, thumbnailSrcSet, content, lastUpdate, language, hijackRegExp, children,
+      title, defaultThumbnailSrc, thumbnailSrcSet, content, lastUpdate, language, children,
       onInternalLinkClick
     } = this.props
     return (
@@ -45,8 +44,7 @@ class Page extends React.PureComponent<PropsType> {
         <Caption title={title} />
         {children}
         <RemoteContent dangerouslySetInnerHTML={{ __html: content }}
-                       onInternalLinkClick={onInternalLinkClick}
-                       hijackRegExp={hijackRegExp} />
+                       onInternalLinkClick={onInternalLinkClick} />
         {lastUpdate && <LastUpdateInfo lastUpdate={lastUpdate} language={language} withText />}
       </>
     )

--- a/src/modules/common/components/RemoteContent.js
+++ b/src/modules/common/components/RemoteContent.js
@@ -63,7 +63,6 @@ type PropsType = {|
   dangerouslySetInnerHTML: {
     __html: string
   },
-  hijackRegExp?: RegExp,
   onInternalLinkClick: string => void,
   centered: boolean
 |}
@@ -100,7 +99,7 @@ class RemoteContent extends React.Component<PropsType> {
     }
     const collection: HTMLCollection<HTMLAnchorElement> = this.sandBoxRef.current.getElementsByTagName('a')
     Array.from(collection).forEach(node => {
-      if ((this.props.hijackRegExp || HIJACK).test(node.href)) {
+      if (HIJACK.test(node.href)) {
         node.addEventListener('click', this.handleClick)
       }
     })


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/). 
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **WEBAPP**.
